### PR TITLE
✨Add -e flags to ignore some directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .idea
 .DS_Store
 
+## LOGS
+*.log
+
 ## BINARY FILES
 coconut
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coconut
 *.a
 *.so
 build
+cmake-build-debug

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .idea
 .DS_Store
+.cache
 
 ## LOGS
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+## IDE FILES
+.vscode
+.idea
+.DS_Store
+
+## BINARY FILES
+coconut
+*.o
+*.a
+*.so
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+project(coconut C)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_compile_options(-Wall -Wextra -Wconversion -Wpedantic)
+
+file(GLOB SOURCES
+        src/*.c
+        src/display/*.c
+        src/errors/*.c
+        src/utils/*.c)
+
+add_executable(coconut ${SOURCES})
+
+target_include_directories(coconut PRIVATE include)
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+##
+## EPITECH PROJECT, 2025
+## coconut
+## File description:
+## Makefile
+##
+
 NAME	=	coconut
 
 all: $(NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,29 @@
-SRC	=	src/coconut.c	\
-		src/flag_handling.c	\
-		src/display/display_additional.c	\
-		src/display/display_errors.c	\
-		src/display/display_usage.c	\
-		src/errors/error_codes.c	\
-		src/errors/read_errors.c	\
-		src/errors/sort_errors.c	\
-		src/utils/file_utils.c	\
-		src/utils/stream_utils.c	\
-		src/utils/utils.c	\
-		src/load_config.c	\
-
-INCLUDE	=	include/
-
-OBJ = 	$(SRC:%.c=%.o)
-
-CFLAGS	+= -Wall -Wextra -I $(INCLUDE)
-
 NAME	=	coconut
 
 all: $(NAME)
 
-$(NAME): $(OBJ)
-	gcc $(OBJ) $(CFLAGS) -o $(NAME)
+.PHONY: $(NAME)
+$(NAME):
+	@mkdir -p build
+	@cd build && CC=gcc cmake -DCMAKE_BUILD_TYPE=Debug ..
+	@cmake --build build
+	@cp build/$(NAME) .
+
+.PHONY: debug
+debug:
+	@mkdir -p build
+	@cd build && CC=gcc cmake -DCMAKE_BUILD_TYPE=Debug \
+ 			-DCMAKE_CXX_FLAGS="-fsanitize=address" \
+ 			-DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" ..
+	@cmake --build build --parallel 12
+	@cp build/$(NAME) .
 
 clean:
-	rm -f $(OBJ)
+	$(RM) -r build
+	$(RM) -r cmake-build-debug
 
 fclean:	clean
-	rm -f $(NAME)
+	$(RM) $(NAME)
 
 re: fclean $(NAME)
 

--- a/include/coconut.h
+++ b/include/coconut.h
@@ -9,6 +9,7 @@ typedef struct arguments_s {
     char *language;
     char *style_checker;
     char *report_file;
+    char **ignored_files;
     bool remove_log_file;
     bool verbose;
     bool run_coding_style;
@@ -57,7 +58,7 @@ enum error_codes {
 // Need to either move these into other files or clean them up
 int display_usage(void);
 error_content_t *read_style_reports(
-    error_stats_t *error_stats, const char *reports_file);
+    error_stats_t *error_stats, const arguments_t *arguments);
 char *get_error_message(const char *error_code);
 void write_errors(
     const error_content_t *errors,

--- a/include/string_macros.h
+++ b/include/string_macros.h
@@ -2,7 +2,7 @@
     #define STRING_MACROS_H_
 
     #define ERROR_STR "%5d   │ %s%-32.32s -> %4s \x1b[0m│ %s\n"
-    #define HANDLED_FLAGS "hcrs:f:vl"
+    #define HANDLED_FLAGS "ehcrs:f:vl"
     #define REMOVE_LOG_REPORT "rm -f coding-style-reports.log"
     #define REPORT_NOT_FOUND "Couldn't read report file\n"
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,13 +1,12 @@
 #ifndef COCONUT_UTILS_H_
     #define COCONUT_UTILS_H_
-
     #include <stdbool.h>
     #include <stdio.h>
     #include <sys/types.h>
 
 int error_severity(const char *line);
 bool is_object_file(const char *filepath);
-ulong get_terminal_size(void);
+unsigned long get_terminal_size(void);
 char *get_config_file(void);
 bool is_file_stream_null(const FILE *file_stream, const char *error_message);
 long get_file_size(const char *filepath);

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ sudo ./install.sh
 Coding-style-checker <br>
 GCC <br>
 Make <br>
+CMake <br>
 
 # Usage
 ```
@@ -24,6 +25,7 @@ Usage: coconut [option]
   -r        Remove log file after displaying errors
   -s [opt]  Sort output either by "file", "error" or "severity" (default "file")
   -l        Add a line between different errors depending on the sorting flag
+  -e [opt]  Exclude a folder from coding style reports
 ```
 
 # TO-DO

--- a/src/coconut.c
+++ b/src/coconut.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** coconut
+*/
+
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/coconut.c
+++ b/src/coconut.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     if (handling_result == 1)
         return 0;
     run_coding_style(arguments.run_coding_style, arguments.style_checker);
-    errors = read_style_reports(&error_stats, arguments.report_file);
+    errors = read_style_reports(&error_stats, &arguments);
     if (errors == NULL)
         return -1;
     write_report(errors, &error_stats, &arguments);

--- a/src/display/display_additional.c
+++ b/src/display/display_additional.c
@@ -4,7 +4,7 @@
 #include "coconut.h"
 #include "utils.h"
 
-static char *dash_line_buffer(ulong size)
+static char *dash_line_buffer(unsigned long size)
 {
     char *buffer = NULL;
 

--- a/src/display/display_additional.c
+++ b/src/display/display_additional.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** display_additional
+*/
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/display/display_errors.c
+++ b/src/display/display_errors.c
@@ -48,7 +48,7 @@ static void write_formatted_error(const error_content_t *error, int error_nb)
 {
     char *error_message = NULL;
     const char *color_code = NULL;
-    char file_and_line[35];
+    char file_and_line[50];
 
     memset(file_and_line, 0, 34);
     strncat(file_and_line, error->filepath, 32);

--- a/src/display/display_errors.c
+++ b/src/display/display_errors.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** display_errors
+*/
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/display/display_usage.c
+++ b/src/display/display_usage.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** display_usage
+*/
+
 #include <unistd.h>
 #include "coconut.h"
 
@@ -11,6 +18,7 @@ int display_usage(void)
         "  -s [opt]  Sort output either by \"file\", \"error\" or "
         "\"severity\" (default \"file\")\n"
         "  -l        Add a line between different errors depending on "
-        "the sorting flag\n", 341);
+        "the sorting flag\n"
+        "  -e [opt]  Exclude a folder from coding style reports\n", 395);
     return 1;
 }

--- a/src/errors/error_codes.c
+++ b/src/errors/error_codes.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** error_codes
+*/
+
 #include <stddef.h>
 #include <string.h>
 #include "coconut.h"

--- a/src/errors/read_errors.c
+++ b/src/errors/read_errors.c
@@ -43,7 +43,7 @@ static error_content_t *read_report_lines(
     if (!list)
         return NULL;
     while (getline(&line, &len, f_stream) != -1) {
-        list = realloc(list, (stats->total + 1) * sizeof(error_content_t));
+        list = realloc(list, (size_t)(stats->total + 1) * sizeof(error_content_t));
         disassemble_error_line(line, &list[stats->total]);
         add_errors(stats, &list[stats->total]);
         stats->total++;

--- a/src/errors/read_errors.c
+++ b/src/errors/read_errors.c
@@ -29,18 +29,39 @@ static void add_errors(
         error_stats->infos++;
 }
 
-static void disassemble_error_line(char *line, error_content_t *content)
+static bool check_ignored_files(
+    const arguments_t *arguments,
+    const error_content_t *error)
+{
+    if (!arguments->ignored_files || !arguments->ignored_files[0])
+        return false;
+    for (int i = 0; arguments->ignored_files[i]; i++) {
+        if (strncmp(arguments->ignored_files[i], &error->filepath[2],
+            strlen(arguments->ignored_files[i])) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void disassemble_error_line(char *line, error_content_t *content,
+    const arguments_t *arguments)
 {
     content->filepath = strdup(strtok(line, ":"));
-    content->line = strdup(strtok(NULL, ":"));
-    content->severity = error_severity(&strtok(NULL, ":")[1]);
-    content->error_code = strndup(&strtok(NULL, ":")[2], 3);
-    if (content->error_code[2] == '\n')
-        content->error_code[2] = 0;
+    if (check_ignored_files(arguments, content) == false) {
+        content->line = strdup(strtok(NULL, ":"));
+        content->severity = error_severity(&strtok(NULL, ":")[1]);
+        content->error_code = strndup(&strtok(NULL, ":")[2], 3);
+        if (content->error_code[2] == '\n')
+            content->error_code[2] = 0;
+    } else {
+        content->filepath = NULL;
+    }
 }
 
 static error_content_t *read_report_lines(
-    error_stats_t *stats, FILE *f_stream)
+    error_stats_t *stats, FILE *f_stream,
+    const arguments_t *arguments)
 {
     char *line = NULL;
     size_t len = 0;
@@ -50,10 +71,13 @@ static error_content_t *read_report_lines(
     if (!list)
         return NULL;
     while (getline(&line, &len, f_stream) != -1) {
-        list = realloc(list, (size_t)(stats->total + 1) * sizeof(error_content_t));
-        disassemble_error_line(line, &list[stats->total]);
-        add_errors(stats, &list[stats->total]);
-        stats->total++;
+        list = realloc(list, (size_t)(stats->total + 1) *
+            sizeof(error_content_t));
+        disassemble_error_line(line, &list[stats->total], arguments);
+        if (list[stats->total].filepath != NULL) {
+            add_errors(stats, &list[stats->total]);
+            stats->total++;
+        }
     }
     if (line)
         free(line);
@@ -61,15 +85,15 @@ static error_content_t *read_report_lines(
 }
 
 error_content_t *read_style_reports(
-    error_stats_t *stats, const char *reports_file)
+    error_stats_t *stats, const arguments_t *arguments)
 {
     FILE *f_stream = NULL;
     error_content_t *list = NULL;
 
-    f_stream = fopen(reports_file, "r");
+    f_stream = fopen(arguments->report_file, "r");
     if (is_file_stream_null(f_stream, REPORT_NOT_FOUND))
         return NULL;
-    list = read_report_lines(stats, f_stream);
+    list = read_report_lines(stats, f_stream, arguments);
     if (list == NULL)
         return NULL;
     fclose(f_stream);

--- a/src/errors/read_errors.c
+++ b/src/errors/read_errors.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** read_errors
+*/
+
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/src/errors/sort_errors.c
+++ b/src/errors/sort_errors.c
@@ -20,7 +20,7 @@ void sort_errors(error_content_t *error_list, int sort_mask, int error_count)
         {NULL, &error_cmp, &severity_cmp};
 
     qsort(error_list,
-        error_count,
+        (size_t)error_count,
         sizeof(error_content_t),
         sort_functions[sort_mask]);
 }

--- a/src/errors/sort_errors.c
+++ b/src/errors/sort_errors.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** sort_errors
+*/
+
 #include "coconut.h"
 #include <stdlib.h>
 #include <string.h>

--- a/src/flag_handling.c
+++ b/src/flag_handling.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** flag_handling
+*/
+
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/load_config.c
+++ b/src/load_config.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** load_config
+*/
+
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** file_utils
+*/
+
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/src/utils/stream_utils.c
+++ b/src/utils/stream_utils.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** stream_utils
+*/
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -1,3 +1,10 @@
+/*
+** EPITECH PROJECT, 2025
+** coconut
+** File description:
+** utils
+*/
+
 #include <sys/ioctl.h>
 #include <stdio.h>
 #include <sys/types.h>

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -19,7 +19,7 @@ int error_severity(const char *line)
     return 3;
 }
 
-ulong get_terminal_size(void)
+unsigned long get_terminal_size(void)
 {
     struct winsize size = {0};
 
@@ -27,5 +27,5 @@ ulong get_terminal_size(void)
         perror("ioctl");
         return 0;
     }
-    return (ulong)size.ws_col;
+    return (unsigned long)size.ws_col;
 }


### PR DESCRIPTION
This pull request includes several important changes to the `coconut` project, focusing on migrating the build system to CMake, adding new features, and improving code consistency. The most significant changes include the addition of a CMake build system, updates to the `Makefile`, introduction of the `-e` flag for excluding folders, and various code refactorings.

### Build System Migration:
* Added a new `CMakeLists.txt` file to define the build configuration and source files for the project.
* Updated the `Makefile` to use CMake for building the project, including new targets for building in debug mode and cleaning up build artifacts.

### New Features:
* Introduced the `-e` flag to exclude specific folders from coding style reports. Updated the `typedef struct arguments_s` in `coconut.h` to include `ignored_files` and modified related functions to handle this new argument. [[1]](diffhunk://#diff-43cb8b41e9fb1417ea7ac63f2e08979e95624c92e17d5aa9f9a90237fff25628R12) [[2]](diffhunk://#diff-43cb8b41e9fb1417ea7ac63f2e08979e95624c92e17d5aa9f9a90237fff25628L60-R61) [[3]](diffhunk://#diff-fabe09ee896fbc3613eb461c691fb257183393d5e4d8a88ea9e2fce5922524acL25-R64) [[4]](diffhunk://#diff-fabe09ee896fbc3613eb461c691fb257183393d5e4d8a88ea9e2fce5922524acL46-R96) [[5]](diffhunk://#diff-d5de33d20a3eaf64ac3d383d5d9d41a150b6c225c491547dc2a10f20f278badeL27-R61) [[6]](diffhunk://#diff-d5de33d20a3eaf64ac3d383d5d9d41a150b6c225c491547dc2a10f20f278badeR83-R91)
* Updated the `readme.md` to reflect the new `-e` flag and added CMake to the list of dependencies. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R18) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R28)

### Code Refactoring:
* Changed the type of `get_terminal_size` from `ulong` to `unsigned long` in `utils.h` and `utils.c` for consistency. [[1]](diffhunk://#diff-95e9251d9e82720a3917beffdcad74f93a0f67b12b4388c9de6205ce71874024L3-R9) [[2]](diffhunk://#diff-172b5bcee8a61f986b74e03a22c257fcc9175fd87c7cc38ba57b6692ee98e178L22-R37)
* Updated various source files to include project headers and added file descriptions for better documentation. [[1]](diffhunk://#diff-b11681f50443fcce5a4f97ffe325a0c7daba7cad7d9b78f3e7d1169ce869d182R1-R7) [[2]](diffhunk://#diff-06a80d4b858f6e58451e03383a3f79caf769176e126bc0acb0a1cacf5123a231R1-R14) [[3]](diffhunk://#diff-6154df41b48e4314e51ad544a090447998d544684e14deddc35698eba6e6eef2R1-R7) [[4]](diffhunk://#diff-9172de3742766de1c296351039932529f4841dac17659f99aa7abc491f92230aR1-R7) [[5]](diffhunk://#diff-2cffb4b3d6b287f4314452550242206035cf66976856aafafdaaf7108e6ce3edR1-R7) [[6]](diffhunk://#diff-fabe09ee896fbc3613eb461c691fb257183393d5e4d8a88ea9e2fce5922524acR1-R7) [[7]](diffhunk://#diff-fb4c9468d09602cef5bdc350cf4b770b0681492374bf08c0ce404dc7f0318669R1-R7) [[8]](diffhunk://#diff-d5de33d20a3eaf64ac3d383d5d9d41a150b6c225c491547dc2a10f20f278badeR1-R10) [[9]](diffhunk://#diff-dd9851ecf52084d48eaf8ab28bf3597f4f7d47bb3594f83f405d711096c70affR1-R7) [[10]](diffhunk://#diff-194ef32373708ed3b07325a2eee22fc712e6eaa4c2f7a2d01ff44d0ce66c2e99R1-R7) [[11]](diffhunk://#diff-b2e00dbae3f6d596188857e649845b5486e34b2c0561e16861dfaaae2f2fcb76R1-R7) [[12]](diffhunk://#diff-172b5bcee8a61f986b74e03a22c257fcc9175fd87c7cc38ba57b6692ee98e178R1-R7)

### Bug Fixes:
* Fixed the buffer size in `write_formatted_error` and updated the `disassemble_error_line` function to handle ignored files correctly. [[1]](diffhunk://#diff-6154df41b48e4314e51ad544a090447998d544684e14deddc35698eba6e6eef2L44-R51) [[2]](diffhunk://#diff-fabe09ee896fbc3613eb461c691fb257183393d5e4d8a88ea9e2fce5922524acL25-R64)

These changes collectively improve the build process, add new functionality, and enhance the maintainability of the codebase.