### PR TITLE
🐛 Fix crash when running verbose on empty file

### DIFF
--- a/src/coconut.c
+++ b/src/coconut.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include "coconut.h"

--- a/src/display/display_errors.c
+++ b/src/display/display_errors.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include "coconut.h"
 #include "string_macros.h"
@@ -22,8 +23,11 @@ static void write_verbose(const error_content_t *error)
     char *line = NULL;
     size_t len = 0;
     int line_nb = 0;
+    struct stat stat_buffer;
 
     if (is_object_file(error->filepath) == true)
+        return;
+    if (stat(error->filepath, &stat_buffer) == -1 || stat_buffer.st_size == 0)
         return;
     file = fopen(error->filepath, "r");
     if (is_file_stream_null(file, "Error opening file\n"))


### PR DESCRIPTION
This pull request aims to Fix #3 
Error handling improvements:

* [`src/display/display_errors.c`](diffhunk://#diff-6154df41b48e4314e51ad544a090447998d544684e14deddc35698eba6e6eef2R26-R31): Updated the `write_verbose` function to include a file status check using `stat`, and added a condition to return if the file size is zero or if the `stat` call fails.